### PR TITLE
feat(demo site): clean up classes, fonts, and ui

### DIFF
--- a/examples/standalone/index.html
+++ b/examples/standalone/index.html
@@ -6,14 +6,9 @@
     <title>Standalone Example | React Toast Component</title>
     <link rel="shortcut icon" href="favicon.ico" />
     <link
-      href="https://fonts.googleapis.com/css?family=Pacifico&display=swap"
-      rel="stylesheet"
-    />
-    <link
       href="https://fonts.googleapis.com/css?family=Indie+Flower|Pacifico&display=swap"
       rel="stylesheet"
     />
-
     <style>
       html {
         background: rgb(80, 204, 176);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11574,6 +11574,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.1.tgz",
       "integrity": "sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw=="
     },
+    "react-icons": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.8.0.tgz",
+      "integrity": "sha512-rA/8GRKjPulft8BSBSMsHkE1AGPqJ7LjNsyk0BE7XjG70Iz62zOled2SJk7LDo8x9z86a3xOstDlKlMZ4pAy7A==",
+      "requires": {
+        "camelcase": "^5.0.0"
+      }
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-draggable": "^4.0.3",
+    "react-icons": "^3.8.0",
     "react-redux": "^7.1.1",
     "react-scripts": "3.1.1",
     "redux": "^4.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -10,37 +10,16 @@
       content="React Toast Component"
     />
     <link rel="apple-touch-icon" href="logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Pacifico&display=swap"
+      rel="stylesheet"
+    />
     <title>React Toast Component</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-
-    <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-150346246-1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -48,7 +27,6 @@
       gtag('js', new Date());
       gtag('config', 'UA-150346246-1');
     </script>
-
     <!-- Hotjar Tracking Code for http://toast.monster -->
     <script>
       (function(h,o,t,j,a,r){

--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,7 @@
   outline: none;
 }
 
-.App-header {
+body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -19,10 +19,19 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   position: relative;
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: "Indie Flower", cursive;
   letter-spacing: -1px;
 }
 
-.App-header h1 {
-  font-style: italic;
+p {
+  margin: 0;
+}
+
+a {
+  text-decoration: none;
+}
+
+h1 {
+  font-family: "Pacifico", serif;
+  line-height: 25px;
 }

--- a/src/Button/index.jsx
+++ b/src/Button/index.jsx
@@ -3,14 +3,14 @@ import React from "react";
 import "./style.css";
 
 export default function Button(props) {
-  const { onClick, classNames, text } = props;
+  const { onClick, classNames } = props;
 
   return (
     <button
       onClick={onClick}
       className={`Button${classNames ? ` ${classNames}` : ""}`}
     >
-      <span>{text}</span>
+      <span role="img" aria-label="click">+</span>
     </button>
   );
 }

--- a/src/Button/style.css
+++ b/src/Button/style.css
@@ -12,6 +12,8 @@
   border: none;
   outline: none;
   border-radius: 50%;
+  color: transparent;
+  font-size: 1.2rem;
 }
 
 .Button:first-child {
@@ -22,6 +24,7 @@
   -webkit-box-shadow: 0 8px 15px 0 rgba(0, 0, 0, 0.3);
   box-shadow: 0 8px 15px 0 rgba(0, 0, 0, 0.4);
   cursor: pointer;
+  color: rgba(0, 0, 0, 0.3);
 }
 
 

--- a/src/Options/index.jsx
+++ b/src/Options/index.jsx
@@ -1,18 +1,16 @@
 import React, { useState } from "react";
-import shortid from "shortid";
 import { connect } from "react-redux";
-// import toastActions from "../toastActions";
-// import ToastContainer from "../ToastContainer";
+import { FaGithub, FaNpm } from 'react-icons/fa';
 import Toast from "../Toast";
 import Button from "../Button";
 
+import OPTIONS from "./options";
 import "./style.css";
 
 const TOAST_NO_REDUX_DURATION = 5000;
 let timeout = null;
 
 function Options(props) {
-  // const { dispatch } = props;
   const defaultOptions = {
     isOpen: true,
     description:
@@ -48,53 +46,17 @@ function Options(props) {
     }, 500);
   };
 
-  const data = [
-    defaultOptions,
-    {
-      isOpen: true,
-      autoDismiss: false,
-      description: "To close this toast, press x.",
-      hasCloseBtn: true,
-      text: "No Dimiss"
-    },
-    {
-      isOpen: true,
-      description:
-        "Your action has been completed. This will go away in a few seconds.",
-      autoDismiss: true,
-      classNames: ["success"],
-      text: "Success"
-    },
-    {
-      isOpen: true,
-      description:
-        "Uh oh. There's something wrong. To close this toast, press x.",
-      classNames: ["error"],
-      hasCloseBtn: true,
-      autoDismiss: false,
-      text: "Error"
-    },
-    {
-      isOpen: true,
-      description:
-        "Some really great info is in here. This will go away in a few seconds.",
-      autoDismiss: true,
-      classNames: ["info"],
-      text: "Info"
-    },
-    {
-      isOpen: true,
-      description:
-        "Uh oh. There might be something wrong. This will go away in a few seconds.",
-      autoDismiss: true,
-      classNames: ["warning"],
-      text: "Warning"
-    }
-  ];
-
   return (
-    <header className="App-header">
-      <h1>React Toast Pure Component</h1>
+    <div className="Options">
+      <a className="Options--header" href="https://www.npmjs.com/package/react-toast-component"><h1>React Toast Pure Component</h1></a>
+      <p className="Options--icons">
+        <a href="https://github.com/tumfoodery/react-toast-component">
+          <FaGithub />
+        </a>
+        <a href="https://www.npmjs.com/package/react-toast-component">
+          <FaNpm />
+        </a>
+      </p>
       <Toast
         isOpen={isOpen}
         title={`${txt ? ` ${txt}` : ""} Notification 🍞`}
@@ -106,44 +68,18 @@ function Options(props) {
         classNames={classNames}
       />
       <div className="Options--buttons">
-        {data.map(options => {
+        {OPTIONS(defaultOptions).map(options => {
           const { classNames } = options;
+          const className = classNames && classNames[0];
           return (
             <Button
-              classNames={classNames && classNames[0]}
+              classNames={className}
               onClick={() => addOptions(options)}
-              key={shortid.generate()}
+              key={className}
             />
           );
         })}
       </div>
-      {/* <ToastContainer /> */}
-      {/* <button
-        onClick={() =>
-          dispatch(
-            toastActions.addToast({
-              title: "Added",
-              description: "Your item was added.",
-              duration: "5000"
-            })
-          )
-        }
-      >
-        ToastContainer
-      </button> */}
-      <p>
-        <b>Github:</b>{" "}
-        <a href="https://github.com/tumfoodery/react-toast-component">
-          https://github.com/tumfoodery/react-toast-component
-        </a>
-      </p>
-      <p>
-        <b>NPM:</b>{" "}
-        <a href="https://www.npmjs.com/package/react-toast-component">
-          https://www.npmjs.com/package/react-toast-component
-        </a>
-      </p>
-      <br />
       <p>
         <img
           src="https://img.shields.io/npm/dt/react-toast-component.svg"
@@ -155,7 +91,7 @@ function Options(props) {
           alt=""
         />
       </p>
-    </header>
+    </div>
   );
 }
 

--- a/src/Options/options.js
+++ b/src/Options/options.js
@@ -1,0 +1,45 @@
+const OPTIONS = (defaultOptions) => [
+  defaultOptions,
+  {
+    isOpen: true,
+    autoDismiss: false,
+    description: "To close this toast, press x.",
+    hasCloseBtn: true,
+    text: "No Dimiss"
+  },
+  {
+    isOpen: true,
+    description:
+      "Your action has been completed. This will go away in a few seconds.",
+    autoDismiss: true,
+    classNames: ["success"],
+    text: "Success"
+  },
+  {
+    isOpen: true,
+    description:
+      "Uh oh. There's something wrong. To close this toast, press x.",
+    classNames: ["error"],
+    hasCloseBtn: true,
+    autoDismiss: false,
+    text: "Error"
+  },
+  {
+    isOpen: true,
+    description:
+      "Some really great info is in here. This will go away in a few seconds.",
+    autoDismiss: true,
+    classNames: ["info"],
+    text: "Info"
+  },
+  {
+    isOpen: true,
+    description:
+      "Uh oh. There might be something wrong. This will go away in a few seconds.",
+    autoDismiss: true,
+    classNames: ["warning"],
+    text: "Warning"
+  }
+]
+
+export default OPTIONS;

--- a/src/Options/style.css
+++ b/src/Options/style.css
@@ -1,17 +1,27 @@
-p {
-  margin: 0;
-}
-
-.Options--buttons,
-.App-header h1,
-.App-header p {
-  padding: 0 10px;
+.Options h1, .Options p, .Options--buttons {
+  letter-spacing: initial;
   width: 100vw;
   text-align: center;
 }
 
 .Options--buttons {
-  padding: 20px 10px 70px;
+  letter-spacing: initial;
+  padding: 0 10px;
+  width: 100vw;
+  text-align: center;
+}
+
+.Options--header {
+  color: #000;
+}
+
+.Options--icons a {
+  color: #000;
+  padding: 0 5px;
+}
+
+.Options--buttons {
+  padding: 20px 10px 40px;
 }
 
 .Options--badge {


### PR DESCRIPTION
# Description

[//]: # (Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)

This adds functionality to the demo site, adds a hover state to the buttons, cleans up css classes - also adds reset code to body (need to dynamically add css reset - https://github.com/tumfoodery/react-toast-component/issues/12).

## Type of change

[//]: # (Please delete options that are not relevant.)

- New feature (non-breaking change which adds functionality)

## Screenshot

_Desktop_
<img width="1317" alt="Screen Shot 2019-10-27 at 11 58 07 PM" src="https://user-images.githubusercontent.com/3586765/67658022-afc40780-f915-11e9-905a-ff19dc180667.png">

_Mobile_
<img src="https://user-images.githubusercontent.com/3586765/67657957-84d9b380-f915-11e9-8bab-2ab0b2943660.png" width="200"/>

## QA Checklist

[//]: # (Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.)

- [x] `npm run build:demo` | http://toast.monster
- [x] safari
- [x] chrome
- [x] firefox